### PR TITLE
SessioonState.py API object name fix for server

### DIFF
--- a/SessionState.py
+++ b/SessionState.py
@@ -17,11 +17,11 @@
 # """
 try:
     import streamlit.ReportThread as ReportThread
-    from streamlit.server.server import Server
+    from streamlit.web.server import Server
 except Exception:
     # Streamlit >= 0.65.0
     import streamlit.report_thread as ReportThread
-    from streamlit.server.server import Server
+    from streamlit.web.server import Server
 
 
 class SessionState(object):


### PR DESCRIPTION
Fix

line 20 and 24 are updated for new streamlit API (October 18, 2024).
 changed:  from streamlit.server.server  -> from streamlit.web.server